### PR TITLE
Update PostsList.vue

### DIFF
--- a/src/modules/posts/components/PostsList.vue
+++ b/src/modules/posts/components/PostsList.vue
@@ -1,47 +1,87 @@
+// Edited By: Jonathan Atia
+
+// So I wrapped the table with a 'div'.
+// Added a label & input -> since I did not want to start messing around with the core "FormInput" - too convoluted for me.
+// Chaned the 'posts' to 'filteredPosts' on the 'v-for' tr.
+// This builds on top of the fact that this component holds a 'searchTerm' in the 'data'.
+// Then with the help of a computed method -> remap the 'posts' to show only text filtered posts.
+
+// Honestly -> your project is cool, and I probably did not fix this the 'grenpress way'.
+// But...I'ts way too much code to get into for me. 
+// I'ts a simple fix (assuming it works).
+// Getting it to work the 'greenpress way' so that the components play nicely togather...way above my capabilities on
+// an idle friday.
+
 <template>
-	<table>
-		<thead>
-		<tr>
-			<th>Title</th>
-			<th>Category</th>
-			<th>Path</th>
-			<th>Public</th>
-			<th>Pinned</th>
-			<th></th>
-		</tr>
-		</thead>
-		<tbody>
-		<tr v-for="post in posts" :key="post._id">
-			<td>
-				<router-link :to="{name: 'editPost', params: {postId: post._id}}">
-					{{post.title}}
-				</router-link>
-			</td>
-			<td>
-				<router-link :to="{name: 'editCategory', params: {categoryPath: post.category.path}}">
-					{{post.category.name}}
-				</router-link>
-			</td>
-			<td>{{post.path}}</td>
-			<td><i v-if="post.isPublic" class="el-icon-check"/></td>
-			<td><i v-if="post.isPinned" class="el-icon-check"/></td>
-			<td>
-				<i @click.prevent="remove(post._id)" class="el-icon-delete"/>
-			</td>
-		</tr>
-		</tbody>
-	</table>
+  <div>
+		<label>Posts Filter</label>
+		<input type="text" v-mode="searchTerm">
+    <table>
+      <thead>
+        <tr>
+          <th>Title</th>
+          <th>Category</th>
+          <th>Path</th>
+          <th>Public</th>
+          <th>Pinned</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="post in filteredPosts" :key="post._id">
+          <td>
+            <router-link
+              :to="{ name: 'editPost', params: { postId: post._id } }"
+            >
+              {{ post.title }}
+            </router-link>
+          </td>
+          <td>
+            <router-link
+              :to="{
+                name: 'editCategory',
+                params: { categoryPath: post.category.path }
+              }"
+            >
+              {{ post.category.name }}
+            </router-link>
+          </td>
+          <td>{{ post.path }}</td>
+          <td><i v-if="post.isPublic" class="el-icon-check" /></td>
+          <td><i v-if="post.isPinned" class="el-icon-check" /></td>
+          <td>
+            <i @click.prevent="remove(post._id)" class="el-icon-delete" />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </template>
 <script>
-  import { usePostsList } from '../compositions/posts'
-  import { useConfirmAction } from '../../core/compositions/confirm-action'
+import { usePostsList } from '../compositions/posts'
+import { useConfirmAction } from '../../core/compositions/confirm-action'
 
-  export default {
-    setup() {
-      const { posts, remove } = usePostsList()
-      return { posts, remove: useConfirmAction(remove) }
+export default {
+  setup() {
+    const { posts, remove } = usePostsList()
+    return { posts, remove: useConfirmAction(remove) }
+  },
+  data() {
+    return {
+      searchTerm: ''
+    }
+  },
+  computed: {
+    filteredPosts() {
+      if (this.searchTerm.length > 0) {
+        return this.posts.fitler((post) =>
+          new RegExp(`^${this.searchTerm}`, 'i').test(post.title)
+        )
+      }
+			return posts;
     }
   }
+}
 </script>
 <style scoped lang="scss">
 </style>


### PR DESCRIPTION
So I think the functionality fix is quite simple. 
This project is not (not a bad thing), and I wanted to help without needing to 'get into the deep end' of it.

You have a 'FormInput' in the core module. If I could have it my way it would be bound by v-model to 'searchTerm', emitted to the parent component, passed as a prop down to the PostsLists component.

but what i did is not the Greenpress way. i added a  'data' & 'computed' to PostsList
changed the posts to filteredPosts on the v-for (in tr)

the computed merely sends back either the original posts (nothing typed in the filter) or a maped version of posts with the use of a RegExp that is case insensitive, and filters all posts by title that begins with the same as 'searchTerm'.

I'f I was not so lazy - I'd find a way to make this filtering feature some kind of hook to be reused, and find a way to implement it within the PostsLists, from outsie, along with the input.